### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-dev-publish.yml
+++ b/.github/workflows/docker-dev-publish.yml
@@ -51,11 +51,11 @@ jobs:
       - name: Install Cosgin
         if: github.event_name != 'pull_request'
         #try using main
-        uses: sigstore/cosign-installer@v3.0.5
+        uses: sigstore/cosign-installer@v3.1.1
 
       - name: Setup Docker buildx
       # try default buildx action v2
-        uses: docker/setup-buildx-action@v2.6.0
+        uses: docker/setup-buildx-action@v2.8.0
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -73,7 +73,7 @@ jobs:
       - name: Extract Docker metadata
         id: meta
         #try with metadata-action v4
-        uses: docker/metadata-action@v4.5.0
+        uses: docker/metadata-action@v4.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -82,7 +82,7 @@ jobs:
       - name: Build and push Docker image
         id: build-and-push
         # try default build and push action v3
-        uses: docker/build-push-action@v4.1.0
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           push: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,11 +53,11 @@ jobs:
       - name: Install Cosgin
         if: github.event_name != 'pull_request'
         #try using main
-        uses: sigstore/cosign-installer@v3.0.5
+        uses: sigstore/cosign-installer@v3.1.1
 
       - name: Setup Docker buildx
       # try default buildx action v2
-        uses: docker/setup-buildx-action@v2.6.0
+        uses: docker/setup-buildx-action@v2.8.0
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -75,7 +75,7 @@ jobs:
       - name: Extract Docker metadata
         id: meta
         #try with metadata-action v4
-        uses: docker/metadata-action@v4.5.0
+        uses: docker/metadata-action@v4.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -84,7 +84,7 @@ jobs:
       - name: Build and push Docker image
         id: build-and-push
         # try default build and push action v3
-        uses: docker/build-push-action@v4.1.0
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.8.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.8.0)** on 2023-06-28T15:33:24Z
* **[sigstore/cosign-installer](https://github.com/sigstore/cosign-installer)** published a new release **[v3.1.1](https://github.com/sigstore/cosign-installer/releases/tag/v3.1.1)** on 2023-06-27T10:31:09Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.1.1](https://github.com/docker/build-push-action/releases/tag/v4.1.1)** on 2023-06-13T11:22:58Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v4.6.0](https://github.com/docker/metadata-action/releases/tag/v4.6.0)** on 2023-06-13T10:28:40Z
