### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-merge-label.yml
+++ b/.github/workflows/auto-merge-label.yml
@@ -7,7 +7,7 @@ jobs:
   merge-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
 
       - name: Merge by labeled
         uses: devmasx/merge-branch@v1.4.0

--- a/.github/workflows/docker-dev-publish.yml
+++ b/.github/workflows/docker-dev-publish.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.0
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.0
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer

--- a/.github/workflows/github-actions-update.yml
+++ b/.github/workflows/github-actions-update.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
