### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-merge-label.yml
+++ b/.github/workflows/auto-merge-label.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -  name: Checkout repository
-         uses: actions/checkout@v4.1.5
+         uses: actions/checkout@v4.2.2
          id: auto-merge
       -  name: auto-merge
          uses: "pascalgn/automerge-action@v0.15.6"

--- a/.github/workflows/docker-dev-publish.yml
+++ b/.github/workflows/docker-dev-publish.yml
@@ -44,25 +44,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.2.2
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosgin
         if: github.event_name != 'pull_request'
         #try using main
-        uses: sigstore/cosign-installer@v3.5.0
+        uses: sigstore/cosign-installer@v3.9.1
 
       - name: Setup Docker buildx
       # try default buildx action v2
-        uses: docker/setup-buildx-action@v3.3.0
+        uses: docker/setup-buildx-action@v3.11.1
         
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         #try with login-actionv2
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -73,7 +73,7 @@ jobs:
       - name: Extract Docker metadata
         id: meta
         #try with metadata-action v4
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -82,7 +82,7 @@ jobs:
       - name: Build and push Docker image
         id: build-and-push
         # try default build and push action v3
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           push: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,25 +46,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.2.2
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosgin
         if: github.event_name != 'pull_request'
         #try using main
-        uses: sigstore/cosign-installer@v3.5.0
+        uses: sigstore/cosign-installer@v3.9.1
 
       - name: Setup Docker buildx
       # try default buildx action v2
-        uses: docker/setup-buildx-action@v3.3.0
+        uses: docker/setup-buildx-action@v3.11.1
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         #try with login-actionv2
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
       - name: Extract Docker metadata
         id: meta
         #try with metadata-action v4
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -84,7 +84,7 @@ jobs:
       - name: Build and push Docker image
         id: build-and-push
         # try default build and push action v3
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/github-actions-update.yml
+++ b/.github/workflows/github-actions-update.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.5
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.6](https://github.com/actions/checkout/releases/tag/v4.1.6)** on 2024-05-16T18:11:28Z
* **[pascalgn/automerge-action](https://github.com/pascalgn/automerge-action)** published a new release **[v0.16.3](https://github.com/pascalgn/automerge-action/releases/tag/v0.16.3)** on 2024-04-12T05:29:19Z
